### PR TITLE
fix(tests): recover unit tests and refactors for PhoneCard and BackButton components

### DIFF
--- a/src/components/BackButton/BackButton.jsx
+++ b/src/components/BackButton/BackButton.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import { Button } from '../Button/Button'
 import "./BackButton.scss";
 
 export const BackButton = () => {
@@ -6,9 +7,11 @@ export const BackButton = () => {
 
   return (
     <nav className="back-bar">
-      <button className="back-button" onClick={() => navigate(-1)}>
-        &lt;  BACK
-      </button>
+      <Button
+        label="< BACK"
+        parentMethod={() => navigate(-1)}
+        variant="back-button" 
+      />
     </nav>
   );
 };

--- a/src/components/BackButton/BackButton.scss
+++ b/src/components/BackButton/BackButton.scss
@@ -1,28 +1,11 @@
 .back-bar {
     background-color: white;
-    padding: 6px 100px; // ⬅️ Menor padding que el navbar
+    padding: 6px 100px; 
     display: flex;
     align-items: center;
     justify-content: flex-start;
 
   }
   
-  .back-button {
-    background: none;
-    border: none;
-    font-size: 14px;
-    font-weight: 400;
-    color: black;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    letter-spacing: 0.5px;
-    text-transform: uppercase;
-    transition: opacity 0.2s ease;
   
-    &:hover {
-      opacity: 0.6;
-    }
-  }
   

--- a/src/components/BackButton/BackButton.test.jsx
+++ b/src/components/BackButton/BackButton.test.jsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BackButton } from './BackButton';
+import { MemoryRouter, useNavigate } from 'react-router-dom'; 
+import { vi } from 'vitest';
+
+// Mock de react-router-dom
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: vi.fn(), // 👈 Aquí ya mockeamos useNavigate como vi.fn()
+  };
+});
+
+describe('BackButton', () => {
+  test('renders the back button with correct label', () => {
+    render(
+      <MemoryRouter>
+        <BackButton />
+      </MemoryRouter>
+    );
+    const button = screen.getByRole('button', { name: /< back/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  test('navigates back when clicked', () => {
+    const navigateMock = vi.fn();
+    useNavigate.mockReturnValue(navigateMock); 
+
+    render(
+      <MemoryRouter>
+        <BackButton />
+      </MemoryRouter>
+    );
+
+    const button = screen.getByRole('button', { name: /< back/i });
+    fireEvent.click(button);
+
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith(-1);
+  });
+});

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -72,5 +72,27 @@
       color: #c3c3c3;
       border-color: #c3c3c3;
     }
+
+  }
+
+  .custom-button.back-button {
+    background: none;
+    border: none;
+    font-size: 14px;
+    font-weight: 400;
+    color: black;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    transition: opacity 0.2s ease;
+    width:auto;
+    padding:0;
+  
+    &:hover {
+      opacity: 0.6;
+    }
   }
   

--- a/src/features/phones/components/phoneCard/PhoneCard.jsx
+++ b/src/features/phones/components/phoneCard/PhoneCard.jsx
@@ -9,6 +9,9 @@ import {
   instantFade,
 } from "@/animations/phoneCard.animations";
 
+const getImageClass = (brand) => 
+  brand.toUpperCase() === "XIAOMI" ? "xiaomi-image" : "phone-card__image";
+
 export const PhoneCard = ({ phone, isCarouselItem = false }) => {
   const id = phone[PHONE_FIELDS.ID];
 
@@ -31,11 +34,7 @@ export const PhoneCard = ({ phone, isCarouselItem = false }) => {
             src={secureUrl(phone[PHONE_FIELDS.IMAGE_URL])}
             alt={phone[PHONE_FIELDS.NAME]}
             loading="lazy"
-            className={`${
-              phone[PHONE_FIELDS.BRAND].toUpperCase() === "XIAOMI"
-                ? "xiaomi-image"
-                : "phone-card__image"
-            }`}
+            className={getImageClass(phone[PHONE_FIELDS.BRAND])}
           />
         </header>
 

--- a/src/features/phones/components/phoneCard/PhoneCard.test.jsx
+++ b/src/features/phones/components/phoneCard/PhoneCard.test.jsx
@@ -23,17 +23,6 @@ describe('PhoneCard', () => {
     expect(screen.getByText('999 EUR')).toBeInTheDocument();
   });
 
-  test('renders phone image with correct alt text', () => {
-    render(
-      <MemoryRouter>
-        <PhoneCard phone={mockPhone} />
-      </MemoryRouter>
-    );
-
-    const image = screen.getByAltText(/iphone 13/i);
-    expect(image).toBeInTheDocument();
-  });
-
   test('renders phone image with correct alt text and src', () => {
     render(
       <MemoryRouter>


### PR DESCRIPTION
This pull request restores changes previously reverted, including:

- Unit tests for PhoneCard component (brand, name, price, image alt text, and navigation).
- Unit tests for BackButton component (label and navigation behavior).
- Extraction of a helper function to determine phone image class by brand.
- Removal of the unused ThemeContext file.
- Minor refactors for better code modularity.

All tests are passing successfully.

This PR ensures that previous work on testing and code structure is correctly restored to the main branch.
